### PR TITLE
Remove dependent-destroy from relation

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -65,7 +65,6 @@ module Globalize
 
         has_many :translations, :class_name  => translation_class.name,
                                 :foreign_key => options[:foreign_key],
-                                :dependent   => :destroy,
                                 :extend      => HasManyExtensions
 
         after_create :save_translations!


### PR DESCRIPTION
Now the related translations are not destroyed with the main object.
